### PR TITLE
Add env option to fix pip install root isue in Docker container

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -4,6 +4,8 @@ WORKDIR /app
 
 COPY ./requirements.txt .
 
+ENV PIP_ROOT_USER_ACTION=ignore
+
 RUN pip3 install -r requirements.txt
 
 COPY *.py .


### PR DESCRIPTION
This PR disables the warning `WARNING: Running pip as the 'root' user can result in broken permissions...`

See: [https://stackoverflow.com/questions/68673221/warning-running-pip-as-the-root-user](https://stackoverflow.com/questions/68673221/warning-running-pip-as-the-root-user)
