### PR TITLE
Set host in server.py to allow Docker run

### DIFF
--- a/backend/server.py
+++ b/backend/server.py
@@ -28,4 +28,4 @@ api.add_resource(Classification, "/classification")
 api.add_resource(Requirements, "/requirements")
 
 if __name__ == "__main__":
-    app.run(debug=True)
+    app.run(debug=True, host="0.0.0.0")


### PR DESCRIPTION
This PR sets the `host` argument to `0.0.0.0` which enables the port forwarding when the server runs in a Docker container.